### PR TITLE
Fixing temperature sensor below 0 celsius

### DIFF
--- a/items/TemperatureSensorItem.js
+++ b/items/TemperatureSensorItem.js
@@ -28,6 +28,10 @@ TemperatureSensorItem.prototype.getOtherServices = function() {
     const otherService = new this.homebridge.hap.Service.TemperatureSensor();
 
     otherService.getCharacteristic(this.homebridge.hap.Characteristic.CurrentTemperature)
+        .setProps({
+            minValue: -1000,
+            maxValue: 1000
+        })
         .on('get', this.getItemState.bind(this))
         .setValue(this.currentTemperature);
 


### PR DESCRIPTION
Hi, I'm really using it for a while now as a manual patch, but through giving it back so others can benefit.

Homebridge TemperatureSensors by default does not support values below 0.

In Celsius we often have below zero during winter so if you have an external temperature sensor this way you can see the real minus celsius value, otherwise you see 0 celsius.